### PR TITLE
ci: test build on pr with fail fast & npmrc

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   test-tauri:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         platform: [macos-latest, ubuntu-22.04, windows-latest]
 
@@ -24,8 +24,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
-      - name: install app dependencies and build it
-        run: npm ci --force && npm run build
+
+      - name: install dependencies
+        run: npm ci -f
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Renovate is having an issue with legacy peer deps, solution is to force with config npmrc